### PR TITLE
fix console class init

### DIFF
--- a/ghost/core/console.py
+++ b/ghost/core/console.py
@@ -36,7 +36,7 @@ class Console(Cmd):
 
     def __init__(self) -> None:
         super().__init__(
-            prompt='(%lineghost%end)> '
+            prompt='(%lineghost%end)> ',
             intro="""%clear%end
    .--. .-.               .-.
   : .--': :              .' `.
@@ -49,7 +49,7 @@ class Console(Cmd):
 """
         )
 
-    self.devices = {}
+        self.devices = {}
 
     def do_exit(self, _) -> None:
         """ Exit Ghost Framework.


### PR DESCRIPTION
# Description

There is missing comma between the super init parameters, also an missing indentation for the self.devices variable

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Its only when i run the program, error happened.